### PR TITLE
fix #5856

### DIFF
--- a/src/components/modal/modal.vue
+++ b/src/components/modal/modal.vue
@@ -366,8 +366,8 @@
             },
             visible (val) {
                 if (val === false) {
-                    this.buttonLoading = false;
                     this.timer = setTimeout(() => {
+                        this.buttonLoading = false;
                         this.wrapShow = false;
                         this.removeScrollEffect();
                     }, 300);


### PR DESCRIPTION
根因：对话框关闭前就调用了this.buttonLoading = false;，而关闭是有动画效果，所以会有短暂按钮恢复为可用
解决方案：把恢复按钮放入到定时器，待对话框彻底消失后再恢复
